### PR TITLE
Potential fix for code scanning alert no. 2: Information exposure through an exception

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -5,6 +5,7 @@ import sys
 import os
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
+import traceback
 from scripts.ai_model import simple_ai_model
 from scripts.ai_utilities import preprocess_data, evaluate_model
 import logging
@@ -49,7 +50,8 @@ def post_data():
     
     except Exception as e:
         logging.error(f"Error processing data: {str(e)}")
-        return jsonify({"error": f"Processing failed: {str(e)}"}), 500
+        logging.error(traceback.format_exc())
+        return jsonify({"error": "Processing failed due to an internal error."}), 500
 
 @app.route('/api/predict', methods=['POST'])
 def predict():


### PR DESCRIPTION
Potential fix for [https://github.com/morningstarxcdcode/Project-Nightingale/security/code-scanning/2](https://github.com/morningstarxcdcode/Project-Nightingale/security/code-scanning/2)

To fix the problem, the error message returned to the user should be generic and not include details from the exception object. Instead, the exception details (including stack trace) should be logged on the server for debugging purposes. Specifically, in the `except` block of `post_data()`, replace the return statement with a generic error message, and log the full stack trace using `logging.error(traceback.format_exc())`. This requires importing the `traceback` module at the top of the file. Only the code in the `post_data()` function (lines 50-52) and the import section need to be changed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
